### PR TITLE
Enable datasource alerting

### DIFF
--- a/src/datasource/plugin.json
+++ b/src/datasource/plugin.json
@@ -6,6 +6,7 @@
   "metrics": true,
   "backend": true,
   "executable": "gpx_slack_kaldb_app_datasource_backend",
+  "alerting": true,
   "info": {
     "description": "Grafana KalDB App",
     "author": {


### PR DESCRIPTION
###  Summary

Sets the datasource config to allow the KalDB datasource to be used as an alertable datasource, per https://grafana.com/docs/grafana/latest/developers/plugins/metadata/

<img width="710" alt="image" src="https://github.com/slackhq/slack-kaldb-app/assets/771133/cb06523b-b54f-4ac5-9d48-a56240820923">
