### PR TITLE
Update http client consistent with opensearch-datasource #118

### DIFF
--- a/pkg/kaldb/client/client_test.go
+++ b/pkg/kaldb/client/client_test.go
@@ -3,7 +3,16 @@ package es
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	jsonEncoding "encoding/json"
+	"encoding/pem"
 	"io/ioutil"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +22,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/opensearch-datasource/pkg/tsdb"
 	"github.com/grafana/opensearch-datasource/pkg/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -56,12 +66,12 @@ func TestClient(t *testing.T) {
 		})
 
 		httpClientScenario(t, "Given a fake http client and a v1.0.0 client with response", &backend.DataSourceInstanceSettings{
-			Database: "[metrics-]YYYY.MM.DD",
 			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
 				"version":                    "1.0.0",
 				"maxConcurrentShardRequests": 6,
 				"timeField":                  "@timestamp",
 				"interval":                   "Daily",
+				"database":                   "[metrics-]YYYY.MM.DD",
 			}),
 		}, func(sc *scenarioContext) {
 			sc.responseBody = `{
@@ -118,13 +128,37 @@ func TestClient(t *testing.T) {
 		})
 	})
 
+	Convey("Test HTTP custom headers", t, func() {
+		httpClientScenario(t, "Given a fake http client", &backend.DataSourceInstanceSettings{
+			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
+				"version":         "1.0.0",
+				"timeField":       "@timestamp",
+				"interval":        "Daily",
+				"httpHeaderName1": "X-Header-Name",
+				"database":        "[metrics-]YYYY.MM.DD",
+			}),
+			DecryptedSecureJSONData: map[string]string{
+				"httpHeaderValue1": "X-Header-Value",
+			},
+		}, func(sc *scenarioContext) {
+			ppl, err := createPPLForTest(sc.client)
+			So(err, ShouldBeNil)
+			_, err = sc.client.ExecutePPLQuery(ppl)
+			So(err, ShouldBeNil)
+
+			Convey("Should send correct header", func() {
+				So(sc.request.Header.Get("X-Header-Name"), ShouldEqual, "X-Header-Value")
+			})
+		})
+	})
+
 	Convey("Test PPL opensearch client", t, func() {
 		httpClientScenario(t, "Given a fake http client and a v1.0.0 client with PPL response", &backend.DataSourceInstanceSettings{
-			Database: "[metrics-]YYYY.MM.DD",
 			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
 				"version":   "1.0.0",
 				"timeField": "@timestamp",
 				"interval":  "Daily",
+				"database":  "[metrics-]YYYY.MM.DD",
 			}),
 		}, func(sc *scenarioContext) {
 			sc.responseBody = `{
@@ -241,4 +275,165 @@ func httpClientScenario(t *testing.T, desc string, ds *backend.DataSourceInstanc
 
 		fn(sc)
 	})
+}
+
+func Test_client_returns_error_with_invalid_json_response(t *testing.T) {
+	Convey("Test opensearch client", t, func() {
+		httpClientScenario(t, "Given a valid payload with invalid json response", &backend.DataSourceInstanceSettings{
+			JSONData: utils.NewRawJsonFromAny(map[string]interface{}{
+				"version":                    "1.0.0",
+				"maxConcurrentShardRequests": 6,
+				"timeField":                  "@timestamp",
+				"interval":                   "Daily",
+				"database":                   "[metrics-]YYYY.MM.DD",
+			}),
+		}, func(sc *scenarioContext) {
+			sc.responseBody = `Unauthorized`
+			ms, err := createMultisearchForTest(sc.client)
+			require.NoError(t, err)
+
+			_, err = sc.client.ExecuteMultisearch(ms)
+
+			assert.Error(t, err)
+			assert.Equal(t, "error while Decoding to MultiSearchResponse: invalid character 'U' looking for beginning of value", err.Error())
+		})
+	})
+}
+
+func Test_TLS_config_included_in_client_passed_from_decrypted_json_data(t *testing.T) {
+	// generates a Certificate Authority certificate and self-signed certificate for the server, similar to https://opensearch.org/docs/latest/security/configuration/generate-certificates/
+	ca, caPrivKey, caPEM, err := generateCaCertificate(t, "root.localhost")
+	require.NoError(t, err)
+	serverCertPEM, serverKeyPEM, err := generateCertificate(t, "server.localhost", ca, caPrivKey)
+	require.NoError(t, err)
+	serverCert, err := tls.X509KeyPair(serverCertPEM.Bytes(), serverKeyPEM.Bytes())
+	require.NoError(t, err)
+	// test server is started with client/server mutual TLS authentication
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {}))
+	rootCaPool := x509.NewCertPool()
+	rootCaPool.AppendCertsFromPEM(caPEM.Bytes())
+	server.TLS = &tls.Config{
+		ClientCAs:    rootCaPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert, // both client and server authenticate using their public/private key pair (mutual authentication)
+		Certificates: []tls.Certificate{serverCert},
+	}
+	server.StartTLS()
+	defer server.Close()
+
+	// self-signed client certificate
+	clientCertPEM, clientKeyPEM, err := generateCertificate(t, "client.localhost", ca, caPrivKey)
+	require.NoError(t, err)
+
+	// verify that newDatasourceHttpClient, when provided the client's JSON data from the config editor, is able to authenticate with the test server mutually
+	client, err := newDatasourceHttpClient(&backend.DataSourceInstanceSettings{
+		JSONData: jsonEncoding.RawMessage(`{"tlsAuth":true, "tlsAuthWithCACert":true}`),
+		DecryptedSecureJSONData: map[string]string{
+			"tlsCACert":     caPEM.String(),
+			"tlsClientCert": clientCertPEM.String(),
+			"tlsClientKey":  clientKeyPEM.String(),
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.Get(server.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func generateCaCertificate(t *testing.T, commonName string) (*x509.Certificate, *rsa.PrivateKey, *bytes.Buffer, error) {
+	t.Helper()
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			CommonName:    commonName,
+			Organization:  []string{"Grafana Labs"},
+			Country:       []string{"France"},
+			Province:      []string{""},
+			Locality:      []string{"Paris"},
+			StreetAddress: []string{"Golden Gate Bridge"},
+			PostalCode:    []string{"75001"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	caPEM := new(bytes.Buffer)
+	if err := pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	if err := pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	}); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return ca, caPrivKey, caPEM, nil
+}
+
+func generateCertificate(t *testing.T, commonName string, ca *x509.Certificate, caPrivKey *rsa.PrivateKey) (*bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"Grafana Labs"},
+			Country:      []string{"France"},
+			Locality:     []string{"Paris"},
+			PostalCode:   []string{"75001"},
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(1, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	if err := pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	if err := pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	return certPEM, certPrivKeyPEM, nil
 }


### PR DESCRIPTION
###  Summary

Updates our http go backend client to be consistent with opensearch-datasource, which this is based off of - https://github.com/grafana/opensearch-datasource/pull/118. This appears to have been breaking the ability to use backend alerting for KalDB as well, with a `"request handler error: [plugin.unavailable] plugin unavailable"` error.

I was able to replicate this locally, and now have it working as expected using the new Grafana Alerts Manager as seen below.
![Screenshot 2023-06-28 at 11 37 01 AM](https://github.com/slackhq/slack-kaldb-app/assets/771133/3f077e49-0f23-482c-b17e-ab159a481754)

