### PR TITLE
Prep 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.2.0
+### New features
+N/A
+
+### Breaking changes
+* Minimum supported Grafana version moved from 8.0 to 9.5
+
+### Bugs squashed
+* Resolved an issue where attempting to use datasource alerting could return an error of `request handler error: [plugin.unavailable] plugin unavailable`
+* Resolved the deprecation warnings on build system by migrating from `@grafana/toolkit` to `@grafana/create-plugin` 
+
+
 ## 0.1.1
 ### New features
 * Enabled datasource alerting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-kaldb-app",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Grafana KalDB App",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
###  Summary

Preps 0.2.0 release with updated build system, datasource alerting fix. Breaking change for those using Grafana < 9.5.