### PR TITLE
Ensure datasource assets are in correct directory during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Package plugin
         id: package-plugin
         run: |
+          mv dist/gpx* dist/datasource
           mv dist ${{ steps.metadata.outputs.plugin-id }}
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
           md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}


### PR DESCRIPTION
###  Summary

The current release process appears to be incorrectly locating the executable files when building the go binaries. This ensures that the gpx files are correctly packaged, matching the `yarn build-go step`:

```json
  "scripts": {
    "build-go": "mage buildAll && mv dist/gpx* dist/datasource",
```