### PR TITLE
Disable aggregations when searching for logs

### DIFF
--- a/src/datasource/QueryBuilder.ts
+++ b/src/datasource/QueryBuilder.ts
@@ -422,6 +422,14 @@ export class QueryBuilder {
       },
     };
 
+    // based off of QueryBuilder raw_data
+    let size, metric;
+    if (target.metrics?.[0]?.type === 'logs') {
+      metric = target.metrics[0];
+      // TODO: This default should be somewhere else together with the one used in the UI
+      size = metric.settings?.limit ? parseInt(metric.settings.limit, 10) : 500;
+    }
+
     this.addAdhocFilters(query, adhocFilters);
 
     if (target.query) {
@@ -433,11 +441,11 @@ export class QueryBuilder {
       });
     }
 
-    query = this.documentQuery(query, 500);
+    // todo - use the limit variable to allow users to set this
+    query = this.documentQuery(query, size || 500);
 
     return {
-      ...query,
-      aggs: this.build(target, null, querystring).aggs,
+      ...query
     };
   }
 

--- a/src/datasource/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
+++ b/src/datasource/components/QueryEditor/MetricAggregationsEditor/SettingsEditor/index.tsx
@@ -63,6 +63,16 @@ export const SettingsEditor = ({ metric, previousMetrics }: Props) => {
         </InlineField>
       )}
 
+      {metric.type === 'logs' && (
+        <InlineField label="Limit" {...inlineFieldProps}>
+          <Input
+            id={`ES-query-${query.refId}_metric-${metric.id}-limit`}
+            onBlur={(e) => dispatch(changeMetricSetting(metric, 'limit', e.target.value))}
+            defaultValue={metric.settings?.limit ?? metricAggregationConfig['logs'].defaults.settings?.limit}
+          />
+        </InlineField>
+      )}
+
       {metric.type === 'cardinality' && (
         <SettingField label="Precision Threshold" metric={metric} settingName="precision_threshold" />
       )}

--- a/src/datasource/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
+++ b/src/datasource/components/QueryEditor/MetricAggregationsEditor/aggregations.ts
@@ -138,6 +138,9 @@ interface RawData extends BaseMetricAggregation {
 
 interface Logs extends BaseMetricAggregation {
   type: 'logs';
+  settings?: {
+    limit?: string;
+  };
 }
 
 export interface BasePipelineMetricAggregation extends MetricAggregationWithField {
@@ -259,6 +262,7 @@ export type MetricAggregationWithSettings =
   | CumulativeSum
   | Derivative
   | RawData
+  | Logs
   | UniqueCount
   | Percentiles
   | ExtendedStats
@@ -271,7 +275,7 @@ export type MetricAggregationWithSettings =
 
 export type MetricAggregationWithMeta = ExtendedStats;
 
-export type MetricAggregation = Count | Logs | PipelineMetricAggregation | MetricAggregationWithSettings;
+export type MetricAggregation = Count | PipelineMetricAggregation | MetricAggregationWithSettings;
 
 // Guards
 // Given the structure of the aggregations (ie. `settings` field being always optional) we cannot

--- a/src/datasource/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/src/datasource/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -189,13 +189,18 @@ export const metricAggregationConfig: MetricsConfiguration = {
   logs: {
     label: 'Logs',
     requiresField: false,
+    isSingleMetric: true,
     isPipelineAgg: false,
     supportsMissing: false,
     supportsMultipleBucketPaths: false,
-    hasSettings: false,
+    hasSettings: true,
     supportsInlineScript: false,
     hasMeta: false,
-    defaults: {},
+    defaults: {
+      settings: {
+        limit: '500',
+      },
+    },
   },
 };
 

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -19,7 +19,7 @@ import {
 import { OpenSearchResponse } from './OpenSearchResponse';
 import { IndexPattern } from './index_pattern';
 import { QueryBuilder } from './QueryBuilder';
-import { defaultBucketAgg, hasMetricOfType } from './query_def';
+import { hasMetricOfType } from './query_def';
 import { FetchError, getBackendSrv, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 import { DataLinkConfig, Flavor, OpenSearchOptions, OpenSearchQuery, QueryType } from './types';
 import { metricAggregationConfig } from './components/QueryEditor/MetricAggregationsEditor/utils';
@@ -575,8 +575,6 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
 
     let queryObj;
     if (target.isLogsQuery || hasMetricOfType(target, 'logs')) {
-      target.bucketAggs = [defaultBucketAgg()];
-      target.metrics = [];
       // Setting this for metrics queries that are typed as logs
       target.isLogsQuery = true;
       queryObj = this.queryBuilder.getLogsQuery(target, adhocFilters, queryString);

--- a/src/datasource/specs/QueryBuilder.test.ts
+++ b/src/datasource/specs/QueryBuilder.test.ts
@@ -534,21 +534,7 @@ describe('QueryBuilder', () => {
 
           expect(query.sort).toEqual({ '@timestamp': { order: 'desc', unmapped_type: 'boolean' } });
 
-          const expectedAggs = {
-            // FIXME: It's pretty weak to include this '1' in the test as it's not part of what we are testing here and
-            // might change as a cause of unrelated changes
-            1: {
-              aggs: {},
-              date_histogram: {
-                extended_bounds: { max: '$timeTo', min: '$timeFrom' },
-                field: '@timestamp',
-                format: 'epoch_millis',
-                interval: '$__interval',
-                min_doc_count: 0,
-              },
-            },
-          };
-          expect(query.aggs).toMatchObject(expectedAggs);
+          expect(query.aggs).toBeUndefined();
         });
 
         it('with querystring', () => {


### PR DESCRIPTION
###  Summary

Disables aggregations when searching for logs, and adds option to provide the doc limit at query.

![Screenshot 2023-07-12 at 4 19 27 PM](https://github.com/slackhq/slack-kaldb-app/assets/771133/01efd251-c8c4-4b2d-8b09-68d9cd781c33)

```json
{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"_all"}
{"size":10,"query":{"bool":{"filter":[{"range":{"_timesinceepoch":{"gte":1689200340611,"lte":1689203940611,"format":"epoch_millis"}}},{"query_string":{"analyze_wildcard":true,"query":"*"}}]}},"sort":{"_timesinceepoch":{"order":"desc","unmapped_type":"boolean"}},"script_fields":{}}
```