### PR TITLE
Prep 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.1
+### New features
+N/A
+
+### Breaking changes
+* Removes deprecated "raw document" type from selectable metric options (prefer "raw data" moving forward)
+
+### Bugs squashed
+* Explore no longer requests an unused aggregation when querying logs
+
 ## 0.2.0
 ### New features
 N/A

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-kaldb-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Grafana KalDB App",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
###  Summary

Preps the 0.2.1 release with fixes to the Explore UIs, specifically for "raw document" and "logs" types.