### PR TITLE
[MON-5382] Detected field rendering

### DIFF
--- a/src/pages/explore.tsx
+++ b/src/pages/explore.tsx
@@ -170,6 +170,30 @@ const KalDBFieldsRenderer = ({ model }: SceneComponentProps<FieldStats>) => {
       return 'fa-li fa fas fa-font';
     }
 
+    if (field.type === 'text') {
+      return 'fa-li fa fas fa-font';
+    }
+
+    if (field.type === 'integer') {
+      return 'fa-li fa fas fa-hashtag';
+    }
+
+    if (field.type === 'float') {
+      return 'fa-li fa fas fa-hashtag';
+    }
+
+    if (field.type === 'double') {
+      return 'fa-li fa fas fa-hashtag';
+    }
+
+    if (field.type === 'long') {
+      return 'fa-li fa fas fa-hashtag';
+    }
+
+    if (field.type === 'boolean') {
+      return 'fa-li fa fas fa-lightbulb';
+    }
+
     if (field.type === 'time') {
       return 'fa-li fa far fa-calendar';
     }
@@ -180,6 +204,30 @@ const KalDBFieldsRenderer = ({ model }: SceneComponentProps<FieldStats>) => {
   const getTitle = (field: Field): string => {
     if (field.type === 'string') {
       return 'String field';
+    }
+
+    if (field.type === 'text') {
+      return 'Text field';
+    }
+
+    if (field.type === 'integer') {
+      return 'Integer field';
+    }
+
+    if (field.type === 'float') {
+      return 'Float field';
+    }
+
+    if (field.type === 'double') {
+      return 'Double field';
+    }
+
+    if (field.type === 'long') {
+      return 'Long field';
+    }
+
+    if (field.type === 'boolean') {
+      return 'Boolean field';
     }
 
     if (field.type === 'time') {


### PR DESCRIPTION
###  Summary
This PR adds in detected field rendering similar to Kibana. A count of fields is listed on the left-hand side,  along with each individual field being listed. There is an icon on the left side that is different depending on the type. And at the top of the list there is a list of the top 10 most "popular" fields.

There's some more work to do here to reach parity, namely around allowing users to click on a given field to see the frequency of the field and also letting them search by that field, but I think this is a solid first pass.

#### Screenshots
![Detected field screenshot](https://github.com/slackhq/slack-kaldb-app/assets/1023070/c06f7878-203e-4bb7-87cf-7c57ec975a7c)

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-kaldb-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-kaldb-app).
