### PR TITLE
[MON-5407] Fix a couple CSS bugs

### DIFF
--- a/src/datasource/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
+++ b/src/datasource/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
@@ -47,12 +47,12 @@ export const FiltersSettingsEditor = ({ value }: Props) => {
           >
             <div
               /*
-              Unfortunately Grfana supplies no way to specify the minimum width for the QueryField and also make it so
-              that when the string is empty it becomes unclickable. This means that if you ever delete the full query,
+              Unfortunately Grafana supplies no way to specify the minimum width for the QueryField and also make it so
+              that when query empty the textbox becomes unclickable. This means that if you ever delete the full query,
               you're no longer able to add a new query until you refresh. Since they also provide no way for us to pass
               in our own custom style, we have to use a CSS selector to selectively override the class with our own
               properties, which is what is down below. I confirmed that the value I selected for it is hardcoded in
-              the code, so it should continue to work until we/they change it
+              their code so it should continue to work until we/they change it
               Link to the relevant code is here: https://github.com/grafana/grafana/blob/03c2efa2d6c2774c60b221f0b4481b4ac5d9efb5/packages/grafana-ui/src/components/QueryField/QueryField.tsx#L212
                */
               className={css`


### PR DESCRIPTION
###  Summary
This PR fixes a couple CSS bugs:
1. A query over the length of 250px would go _behind_ the other components
2. If you deleted your entire query you wouldn't be able to click the query textbox anymore

Demos of the old/new behavior are below.

#### Old behavior
https://github.com/slackhq/slack-kaldb-app/assets/1023070/29c82857-b1a0-4587-a6d1-fe8bacc05524


#### New behavior
https://github.com/slackhq/slack-kaldb-app/assets/1023070/17328c63-f055-45e4-8962-01f6208cac9d



### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-kaldb-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-kaldb-app).
