### PR TITLE
Fixed field list background color in dark mode

### DIFF
--- a/src/pages/explore.tsx
+++ b/src/pages/explore.tsx
@@ -34,6 +34,7 @@ import {
   Input,
   Counter,
   LoadingPlaceholder,
+  useTheme2
 } from '@grafana/ui';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -247,11 +248,12 @@ const KalDBFieldsList = (fields: Field[], topTenMostPopularFields: Field[]) => {
     return 'Unknown field';
   };
 
+
   return (
     <div>
       <div
         style={{
-          backgroundColor: '#e6f1fa',
+          backgroundColor: useTheme2().isDark ? '#343741' : '#e6f1fa',
         }}
       >
         <span


### PR DESCRIPTION
###  Summary
Previous to this we were hardcoding in the background color irrespective of whether the user was using dark mode or not. This PR fixes that and sets a reasonable color depending on what mode the user is using.

Resolves https://github.com/slackhq/slack-kaldb-app/issues/35

#### Screenshots
#### Before light
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/bbbad9ec-010d-4ee3-b34c-3b756ee3d48d)


#### Before dark
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/eab78c98-644c-4478-8b2d-aeac910232f7)


#### After light
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/afb02dcf-cb7b-443b-afde-aff2d5be5666)

#### After dark
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/ef7c7c57-b9fe-4e9e-828d-055a9c858967)


### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-kaldb-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-kaldb-app).
