### PR TITLE
Fix double query

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,5 @@
   "engines": {
     "node": ">=16"
   },
-  "packageManager": "yarn@"
+  "packageManager": "yarn@1.22.21"
 }

--- a/src/datasource/OpenSearchResponse.ts
+++ b/src/datasource/OpenSearchResponse.ts
@@ -40,8 +40,9 @@ export class OpenSearchResponse {
       }
 
       switch (metric.type) {
+        case 'logs':
         case 'count': {
-          newSeries = { datapoints: [], metric: 'count', props, refId: target.refId };
+          newSeries = { datapoints: [], metric: metric.type, props, refId: target.refId };
           for (let i = 0; i < esAgg.buckets.length; i++) {
             const bucket = esAgg.buckets[i];
             const value = bucket.doc_count;


### PR DESCRIPTION
###  Summary
Right now we're making two queries to the KalDB backend. One for the histogram data, and one for the logging data. This PR combines that into a single query to reduce the load imposed on the backend and improve the frontend performance. In very unofficial and adhoc testing (via the Chrome Performance tool and multiple refreshes), this resulted in ~0.5 - 1 second improved load time.

Before:
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/1f0fe7e1-6af7-4d90-90cb-e4bd0d860787)


After:
![image](https://github.com/slackhq/slack-kaldb-app/assets/1023070/ee741a4d-9a73-41a1-8cbe-0f936a7654eb)

I also had to pin the `yarn` version due to [this](https://www.github.com/yarnpkg/yarn/issues/9015) issue.

Resolves https://github.com/slackhq/slack-kaldb-app/issues/38

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-kaldb-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-kaldb-app).
