### PR TITLE
Improve performance of fields list rendering and application as a whole

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -13,10 +13,13 @@ import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import { Configuration } from 'webpack';
 
+
 import { getPackageJson, getPluginJson, hasReadme, getEntries } from './utils';
 import { SOURCE_DIR, DIST_DIR } from './constants';
 
 const pluginJson = getPluginJson();
+const TerserPlugin = require("terser-webpack-plugin");
+
 
 const config = async (env): Promise<Configuration> => ({
   cache: {
@@ -196,6 +199,17 @@ const config = async (env): Promise<Configuration> => ({
     modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
     unsafeCache: true,
   },
+
+  optimization: {
+    minimize: true,
+    usedExports: true,
+    minimizer: [new TerserPlugin({
+      terserOptions: {
+        sourceMap: true,
+        compress: true
+      }
+    })]
+  }
 });
 
 export default config;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,3 +20,4 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
       GF_PATHS_PLUGINS: "/var/lib/grafana/plugins"
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "slack-kaldb-app,slack-kaldb-app-backend-datasource"
+      GF_SERVER_ENABLE_GZIP: "true"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-dom": "17.0.2",
     "react-use": "17.4.0",
     "react-virtualized-auto-sizer": "1.0.2",
+    "react-window": "^1.8.10",
     "rxjs": "7.8.0",
     "semver": "7.3.7",
     "tslib": "2.5.3",
@@ -100,5 +101,6 @@
   "engines": {
     "node": ">=16"
   },
-  "packageManager": "yarn@1.22.21"
+  "packageManager": "yarn@1.22.21",
+  "sideEffects": false
 }

--- a/src/datasource/components/Toggletip.tsx
+++ b/src/datasource/components/Toggletip.tsx
@@ -183,7 +183,7 @@ export interface ToggletipContentProps {
   update?: () => void;
 }
 
-export type ToggletipContent = string | React.ReactElement | ((props: ToggletipContentProps) => JSX.Element);
+export type ToggletipContent = string | React.ReactElement | (() => React.ReactElement);
 
 export interface ToggletipProps {
   /** The theme used to display the toggletip */
@@ -243,7 +243,7 @@ export const Toggletip = React.memo(
       return undefined;
     }, [controlledVisible, closeToggletip]);
 
-    const { getArrowProps, getTooltipProps, setTooltipRef, setTriggerRef, visible, update } = usePopperTooltip({
+    const { getArrowProps, getTooltipProps, setTooltipRef, setTriggerRef, visible } = usePopperTooltip({
       visible: controlledVisible,
       placement: placement,
       interactive: true,
@@ -256,6 +256,7 @@ export const Toggletip = React.memo(
         }
       },
     });
+
 
     return (
       <>
@@ -283,8 +284,7 @@ export const Toggletip = React.memo(
               )}
               <div ref={contentRef} {...getArrowProps({ className: style.arrow })} />
               <div className={style.body}>
-                {(typeof content === 'string' || React.isValidElement(content)) && content}
-                {typeof content === 'function' && update && content({ update })}
+                {(typeof content === 'function' && React.isValidElement(content())) && content()}
               </div>
               {Boolean(footer) && <div className={style.footer}>{footer}</div>}
             </div>

--- a/src/datasource/types.ts
+++ b/src/datasource/types.ts
@@ -103,7 +103,6 @@ export interface ValueFrequency {
 export interface Field {
   name: string;
   type: string;
-  mostCommonValues: ValueFrequency[];
   numberOfLogsFieldIsIn: number;
-  totalNumberOfLogs: number;
+  unmappedFieldValuesArray: any[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8879,6 +8879,14 @@ react-window@1.8.8:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
+react-window@^1.8.10:
+  version "1.8.10"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.10.tgz#9e6b08548316814b443f7002b1cf8fd3a1bdde03"
+  integrity sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
+
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"


### PR DESCRIPTION
###  Summary
This PR greatly improves the performance of our fields list rendering and the application as a whole. The optimizations applied were:
* Adding minification and tree shaking (these may have already been present for production builds, I was a bit unclear reading the docs)
* Adding `gzip` compression to Grafana network requests (this will need to be enabled as well in production environments, but I enabled it here in the Docker container and saw dramatic gains)
* Virtualized the field list
* Swapped the field value calculation, and the whole component, to be lazy which should also heavily cut down on the amount of work done

There's still more work to do here to get things as optimized as we can, but we're currently at a place where the three biggest causes for performance issues are:
* The current log table implementation. We don't have much control here as it's owned by Grafana, but we're planning on doing a rewrite here soon.
* The network request to KalDB. Sometimes this is fast, sometimes this is slow, but the UI is stuck in a holding pattern until it returns.
* Grafana itself. By far the largest source of the browser having to request and load JS that never gets used is from Grafana as it seems their current code splitting and/or tree shaking process could use some work. This results in ~1 second extra load time for us according to Lighthouse.

#### Results
Below are screenshots from Lighthouse before/after this PR was applied. In both cases I tried to refresh once or twice before running the test to ensure that the network request was as fast as it reasonably could be.

**Before:**
![Before optimizations](https://github.com/slackhq/slack-kaldb-app/assets/1023070/71f7692f-1d04-42c4-9967-f45ff16406ec)

**After:**
![After optimizations](https://github.com/slackhq/slack-kaldb-app/assets/1023070/5904eb8e-5def-44a1-9597-f971c10de47b)



Resolves https://github.com/slackhq/slack-kaldb-app/issues/37

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-kaldb-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [ ] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-kaldb-app).
