### PR TITLE
Set the query default to be `*:*` instead of `*`

### DIFF
--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -309,8 +309,8 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
   }
 
   private interpolateLuceneQuery(queryString: string, scopedVars: ScopedVars) {
-    // Lucene Lucene queryString should always be '*' if empty string
-    return getTemplateSrv().replace(queryString, scopedVars, 'lucene') || '*';
+    // Lucene Lucene queryString should always be '*:*' if empty string
+    return getTemplateSrv().replace(queryString, scopedVars, 'lucene') || '*:*';
   }
 
   private interpolatePPLQuery(queryString: string, scopedVars: ScopedVars) {
@@ -568,9 +568,9 @@ export class OpenSearchDatasource extends DataSourceApi<OpenSearchQuery, OpenSea
     // @ts-ignore
     // add global adhoc filters to timeFilter
     const adhocFilters = getTemplateSrv().getAdhocFilters(this.name);
-    // Lucene queryString should always be '*' if empty string
+    // Lucene queryString should always be '*:*' if empty string
     if (!queryString || queryString === '') {
-      queryString = '*';
+      queryString = '*:*';
     }
 
     let queryObj;


### PR DESCRIPTION
###  Summary
We currently have the query default to be `*` instead of `*:*` which is no longer accurate. This PR updates it to work with the newest system

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-astra-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-astra-app).
