### PR TITLE
Cut a release for v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.2
+### New features
+* N/A
+
+### Breaking changes
+* N/A
+
+### Bugs squashed
+* Swapped the default query to be `*:*` instead of `*`. This was resulting in
+a failure to load logs when using newer querying paths
+
 ## 0.6.1
 ### New features
 * N/A

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-astra-app",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Grafana Astra App",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
###  Summary
Cuts the v0.6.2 release

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/slack-astra-app/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [ ] I've written tests to cover the new code and functionality included in this PR.
* [X] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/slackhq/slack-astra-app).
